### PR TITLE
Porting databricks support from v1 codebase

### DIFF
--- a/src/pbi/api/dataset.py
+++ b/src/pbi/api/dataset.py
@@ -50,7 +50,7 @@ class Dataset:
             connection = json.loads(datasource.connection_details)
             server = connection.get("server")
             url = connection.get("url")
-            extension = connection.get('extensionDataSourceKind')
+            extension = connection.get("extensionDataSourceKind")
 
             if server:  # Server-based connections (e.g. Azure Data Warehouse)
                 if server in credentials:
@@ -58,9 +58,9 @@ class Dataset:
                     cred = credentials.get(server)
 
                     if "token" in cred:
-                        datasource.update_credentials('OAuth2', token=cred['token'])
+                        datasource.update_credentials("OAuth2", token=cred["token"])
                     elif "username" in cred:
-                        datasource.update_credentials('Basic', username=cred['username'], password=cred['password'])
+                        datasource.update_credentials("Basic", username=cred["username"], password=cred["password"])
                 else:
                     print(f"*** No credentials provided for {server}. Using existing credentials.")
 
@@ -73,21 +73,21 @@ class Dataset:
                     cred = credentials.get(domain)
 
                     if "token" in cred:
-                        datasource.update_credentials('OAuth2', token=cred['token'])
+                        datasource.update_credentials("OAuth2", token=cred["token"])
                     elif "username" in cred:
-                        datasource.update_credentials('Basic', username=cred['username'], password=cred['password'])
+                        datasource.update_credentials("Basic", username=cred["username"], password=cred["password"])
                 else:
                     print(f"*** No credentials provided for {domain}. Using existing credentials.")
 
-            elif extension == 'Databricks':
-                extension_path = json.loads(connection['extensionDataSourcePath'])
-                cluster = extension_path.get('httpPath')
-                print(f'*** Updating credentials for {cluster}')
+            elif extension == "Databricks":
+                extension_path = json.loads(connection["extensionDataSourcePath"])
+                cluster = extension_path.get("httpPath")
+                print(f"*** Updating credentials for {cluster}")
                 cred = credentials.get(cluster)
                 if cluster in credentials:
-                    datasource.update_credentials('Key', token=cred['token'])
+                    datasource.update_credentials("Key", token=cred["token"])
                 else:
-                    print(f'*** No credentials provided for {cluster}. Using existing credentials.')
+                    print(f"*** No credentials provided for {cluster}. Using existing credentials.")
 
             else:
                 print(f"*** No credentials provided for {connection}. Using existing credentials.")

--- a/src/pbi/api/dataset.py
+++ b/src/pbi/api/dataset.py
@@ -1,8 +1,10 @@
-import time
 import json
-import requests
+import time
 from urllib.parse import urlparse
+
+import requests
 from pbi.tools import handle_request
+
 from .datasource import Datasource
 
 
@@ -60,9 +62,15 @@ class Dataset:
                     if "token" in cred:
                         datasource.update_credentials("OAuth2", token=cred["token"])
                     elif "username" in cred:
-                        datasource.update_credentials("Basic", username=cred["username"], password=cred["password"])
+                        datasource.update_credentials(
+                            "Basic",
+                            username=cred["username"],
+                            password=cred["password"],
+                        )
                 else:
-                    print(f"*** No credentials provided for {server}. Using existing credentials.")
+                    print(
+                        f"*** No credentials provided for {server}. Using existing credentials."
+                    )
 
             elif url:  # Web-based connections (e.g. Application Insights API)
                 domain = urlparse(
@@ -75,9 +83,15 @@ class Dataset:
                     if "token" in cred:
                         datasource.update_credentials("OAuth2", token=cred["token"])
                     elif "username" in cred:
-                        datasource.update_credentials("Basic", username=cred["username"], password=cred["password"])
+                        datasource.update_credentials(
+                            "Basic",
+                            username=cred["username"],
+                            password=cred["password"],
+                        )
                 else:
-                    print(f"*** No credentials provided for {domain}. Using existing credentials.")
+                    print(
+                        f"*** No credentials provided for {domain}. Using existing credentials."
+                    )
 
             elif extension == "Databricks":
                 extension_path = json.loads(connection["extensionDataSourcePath"])
@@ -87,10 +101,14 @@ class Dataset:
                 if cluster in credentials:
                     datasource.update_credentials("Key", token=cred["token"])
                 else:
-                    print(f"*** No credentials provided for {cluster}. Using existing credentials.")
+                    print(
+                        f"*** No credentials provided for {cluster}. Using existing credentials."
+                    )
 
             else:
-                print(f"*** No credentials provided for {connection}. Using existing credentials.")
+                print(
+                    f"*** No credentials provided for {connection}. Using existing credentials."
+                )
 
     def trigger_refresh(self):
         """Trigger a refresh of this dataset. This is an async call and you will need to check the refresh status separately using :meth:`~get_refresh_state`

--- a/src/pbi/api/datasource.py
+++ b/src/pbi/api/datasource.py
@@ -32,33 +32,32 @@ class Datasource:
         """
 
         if type == "OAuth2":
-            credentials = {"credentialData": [{
-                "name": "accessToken",
-                "value": token.get_token()
-            }]}
+            credentials = {
+                "credentialData": [{"name": "accessToken", "value": token.get_token()}]
+            }
         elif type == "Basic":
-            credentials = {"credentialData": [{
-                "name": "username",
-                "value": username
-            }, {
-                "name": "password",
-                "value": password
-            }]}
+            credentials = {
+                "credentialData": [
+                    {"name": "username", "value": username},
+                    {"name": "password", "value": password}
+                ]
+            }
         elif type == "Key":
-            credentials = {"credentialData": [{
-                "name": "key",
-                "value": token
-            }]}
+            credentials = {
+                "credentialData": [{"name": "key", "value": token}]
+            }
 
-        payload = {"credentialDetails": {
-            "credentialType": type,
-            "credentials": json.dumps(credentials),
-            "encryptedConnection": "Encrypted",
-            "encryptionAlgorithm": "None",
-            "privacyLevel": "Organizational",
-            "useCallerAADIdentity": "False", # required to avoid direct query connections 'expiring'
-            "useEndUserOAuth2Credentials": "False" # required to avoid direct query connections 'expiring'
-        }}
+        payload = {
+            "credentialDetails": {
+                "credentialType": type,
+                "credentials": json.dumps(credentials),
+                "encryptedConnection": "Encrypted",
+                "encryptionAlgorithm": "None",
+                "privacyLevel": "Organizational",
+                "useCallerAADIdentity": "False", # required to avoid direct query connections 'expiring'
+                "useEndUserOAuth2Credentials": "False" # required to avoid direct query connections 'expiring'
+            }
+        }
 
         r = requests.patch(
             f"https://api.powerbi.com/v1.0/myorg/gateways/{self.gateway_id}/datasources/{self.id}",

--- a/src/pbi/api/datasource.py
+++ b/src/pbi/api/datasource.py
@@ -19,43 +19,46 @@ class Datasource:
         self.gateway_id = datasource["gatewayId"]
         self.connection_details = datasource["connectionDetails"]
 
-    def update_credentials(self, username=None, password=None, token=None):
+    def update_credentials(self, type, username=None, password=None, token=None):
         """Use the provided credentials to reauthenticate datasources connected to this dataset. If any of the provided credentials do not match the data source they will be skipped.
 
-        Currently, only database credentials are supported using either SQL logins or oauth tokens.
+        Currently, either database (using either SQL logins or oauth tokens) or databricks (using PAT tokens) credentials are supported.
 
         Warning: If you use the oauth method, then authentiaction will only remain valid until the token expires - you may need to reauthenticate before refreshing; the token may expire before the refresh has completed in large models.
-
+        :param type: the type of authentication method to be used by the PBI service: OAuth2, Basic or Key
         :param username: username value if using SQL authentication; the ``password`` must also be provided
         :param password: password value if using SQL authentication; the ``username`` must also be provided
         :param token: valid oauth token (an alternative to passing username and password)
         """
 
-        if token:
-            auth = "OAuth2"
-            credentials = {
-                "credentialData": [{"name": "accessToken", "value": token.get_token()}]
-            }
-        else:
-            auth = "Basic"
-            credentials = {
-                "credentialData": [
-                    {"name": "username", "value": username},
-                    {"name": "password", "value": password},
-                ]
-            }
+        if type == "OAuth2":
+            credentials = {"credentialData": [{
+                "name": "accessToken",
+                "value": token.get_token()
+            }]}
+        elif type == "Basic":
+            credentials = {"credentialData": [{
+                "name": "username",
+                "value": username
+            }, {
+                "name": "password",
+                "value": password
+            }]}
+        elif type == "Key":
+            credentials = {"credentialData": [{
+                "name": "key",
+                "value": token
+            }]}
 
-        payload = {
-            "credentialDetails": {
-                "credentialType": auth,
-                "credentials": json.dumps(credentials),
-                "encryptedConnection": "Encrypted",
-                "encryptionAlgorithm": "None",
-                "privacyLevel": "Organizational",
-                "useCallerAADIdentity": "False",  # required to avoid direct query connections 'expiring'
-                "useEndUserOAuth2Credentials": "False",  # required to avoid direct query connections 'expiring'
-            }
-        }
+        payload = {"credentialDetails": {
+            "credentialType": type,
+            "credentials": json.dumps(credentials),
+            "encryptedConnection": "Encrypted",
+            "encryptionAlgorithm": "None",
+            "privacyLevel": "Organizational",
+            "useCallerAADIdentity": "False", # required to avoid direct query connections 'expiring'
+            "useEndUserOAuth2Credentials": "False" # required to avoid direct query connections 'expiring'
+        }}
 
         r = requests.patch(
             f"https://api.powerbi.com/v1.0/myorg/gateways/{self.gateway_id}/datasources/{self.id}",

--- a/src/pbi/api/datasource.py
+++ b/src/pbi/api/datasource.py
@@ -1,4 +1,5 @@
 import json
+
 import requests
 from pbi.tools import handle_request
 
@@ -39,13 +40,11 @@ class Datasource:
             credentials = {
                 "credentialData": [
                     {"name": "username", "value": username},
-                    {"name": "password", "value": password}
+                    {"name": "password", "value": password},
                 ]
             }
         elif type == "Key":
-            credentials = {
-                "credentialData": [{"name": "key", "value": token}]
-            }
+            credentials = {"credentialData": [{"name": "key", "value": token}]}
 
         payload = {
             "credentialDetails": {
@@ -54,8 +53,8 @@ class Datasource:
                 "encryptedConnection": "Encrypted",
                 "encryptionAlgorithm": "None",
                 "privacyLevel": "Organizational",
-                "useCallerAADIdentity": "False", # required to avoid direct query connections 'expiring'
-                "useEndUserOAuth2Credentials": "False" # required to avoid direct query connections 'expiring'
+                "useCallerAADIdentity": "False",  # required to avoid direct query connections 'expiring'
+                "useEndUserOAuth2Credentials": "False",  # required to avoid direct query connections 'expiring'
             }
         }
 


### PR DESCRIPTION
Implementing databricks datasource support
- Updated  datasource.update_credentials method to require the credential type to be passed as an argument and added support for 'Key' type credentials (e.g. databricks PAT tokens)
- Updated dataset.authenticate method to work with the datasource.update_credential method changes